### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -18,6 +18,6 @@ class Plugin extends \craft\base\Plugin
         parent::init();
         // Load custom filters
         $formatter = new FocalPointFormatter();
-        Craft::$app->view->twig->addExtension(new FocalPointTwigExtensions($formatter));
+        Craft::$app->view->registerTwigExtension(new FocalPointTwigExtensions($formatter));
     }
 }


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.